### PR TITLE
Add scene transitions

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -18,6 +18,7 @@ config/icon="res://icon.svg"
 [autoload]
 
 PlayerVariables="*res://scripts/PlayerVariables.gd"
+SceneTransition="*res://scenes/scene_transition.tscn"
 
 [display]
 

--- a/scenes/scene_transition.tscn
+++ b/scenes/scene_transition.tscn
@@ -1,0 +1,58 @@
+[gd_scene load_steps=5 format=3 uid="uid://dc6ygs4b0qa0w"]
+
+[ext_resource type="Script" path="res://scripts/SceneTransition.gd" id="1_deulu"]
+
+[sub_resource type="Animation" id="Animation_af3uf"]
+resource_name = "RESET"
+length = 0.01
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("ColorRect:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Color(1, 1, 1, 0)]
+}
+
+[sub_resource type="Animation" id="Animation_xvbwj"]
+resource_name = "dissolve"
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("ColorRect:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 1),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_wctea"]
+_data = {
+"RESET": SubResource("Animation_af3uf"),
+"dissolve": SubResource("Animation_xvbwj")
+}
+
+[node name="SceneTransition" type="CanvasLayer"]
+script = ExtResource("1_deulu")
+
+[node name="ColorRect" type="ColorRect" parent="."]
+modulate = Color(1, 1, 1, 0)
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+color = Color(0, 0, 0, 1)
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+"": SubResource("AnimationLibrary_wctea")
+}

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -34,7 +34,7 @@ func _ready():
 
 func on_timer_tick():
 	if time_remaining == 0:
-		get_tree().change_scene_to_file("res://scenes/PowerUpSelect.tscn")
+		SceneTransition.change_scene_to_file("res://scenes/PowerUpSelect.tscn")
 	else:
 		time_remaining -= 1
 		time_remaining_label.text = "Time remaining: " + str(time_remaining)

--- a/scripts/PowerUpSelect.gd
+++ b/scripts/PowerUpSelect.gd
@@ -84,4 +84,4 @@ func on_score_updated():
 	score.text = "Available Points: " + str(_player_variables.player_score)
 
 func on_continue():
-	get_tree().change_scene_to_file("res://scenes/main.tscn")
+	SceneTransition.change_scene_to_file("res://scenes/main.tscn")

--- a/scripts/SceneTransition.gd
+++ b/scripts/SceneTransition.gd
@@ -1,0 +1,14 @@
+extends CanvasLayer
+
+func change_scene_to_file(scene_file_path: String) -> void:
+	"""
+	Use this function to change scenes, which wraps get_tree().change_scene()
+	with a fade in and fade out animation.
+	
+	Args:
+		scene_file_path - file path to the .tscn scene file.
+	"""
+	$AnimationPlayer.play('dissolve')
+	await $AnimationPlayer.animation_finished
+	get_tree().change_scene_to_file(scene_file_path)
+	$AnimationPlayer.play_backwards('dissolve')


### PR DESCRIPTION
Instead of `get_tree().change_scene_to_file`, you can now use `SceneTransition.change_scene_to_file()` to wrap a scene transition in a fade-in and out animation.